### PR TITLE
modernize

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ This package should be used with [bittorrent-protocol](https://www.npmjs.com/pac
 Say you're already using `bittorrent-protocol`. Your code might look something like this:
 
 ```js
-var Protocol = require('bittorrent-protocol')
-var net = require('net')
+const Protocol = require('bittorrent-protocol')
+const net = require('net')
 
-net.createServer(function (socket) {
+net.createServer(socket => {
   var wire = new Protocol()
   socket.pipe(wire).pipe(socket)
 
   // handle handshake
-  wire.on('handshake', function (infoHash, peerId) {
+  wire.on('handshake', (infoHash, peerId) => {
     wire.handshake(new Buffer('my info hash'), new Buffer('my peer id'))
   })
 
@@ -48,12 +48,12 @@ net.createServer(function (socket) {
 To add support for BEP 9, simply modify your code like this:
 
 ```js
-var Protocol = require('bittorrent-protocol')
-var net = require('net')
-var ut_metadata = require('ut_metadata')
+const Protocol = require('bittorrent-protocol')
+const net = require('net')
+const ut_metadata = require('ut_metadata')
 
-net.createServer(function (socket) {
-  var wire = new Protocol()
+net.createServer(socket => {
+  const wire = new Protocol()
   socket.pipe(wire).pipe(socket)
 
   // initialize the extension
@@ -65,7 +65,7 @@ net.createServer(function (socket) {
   wire.ut_metadata.fetch()
 
   // 'metadata' event will fire when the metadata arrives and is verified to be correct!
-  wire.ut_metadata.on('metadata', function (metadata) {
+  wire.ut_metadata.on('metadata', metadata => {
     // got metadata!
 
     // Note: the event will not fire if the peer does not support ut_metadata, if they
@@ -75,12 +75,12 @@ net.createServer(function (socket) {
 
   // optionally, listen to the 'warning' event if you want to know that metadata is
   // probably not going to arrive for one of the above reasons.
-  wire.ut_metadata.on('warning', function (err) {
+  wire.ut_metadata.on('warning', err => {
     console.log(err.message)
   })
 
   // handle handshake
-  wire.on('handshake', function (infoHash, peerId) {
+  wire.on('handshake', (infoHash, peerId) => {
     wire.handshake(new Buffer('my info hash'), new Buffer('my peer id'))
   })
 
@@ -95,7 +95,7 @@ Initialize the extension. If you have the torrent metadata (Buffer), pass it int
 `ut_metadata` constructor so it's made available to the peer.
 
 ```js
-var metadata = fs.readFileSync(__dirname + '/file.torrent')
+const metadata = fs.readFileSync(__dirname + '/file.torrent')
 wire.use(ut_metadata(metadata))
 ```
 
@@ -119,7 +119,7 @@ Fired when metadata is available and verified to be correct. Called with a singl
 parameter of type Buffer.
 
 ```js
-wire.ut_metadata.on('metadata', function (metadata) {
+wire.ut_metadata.on('metadata', metadata => {
   console.log(Buffer.isBuffer(metadata)) // true
 })
 ```
@@ -136,7 +136,7 @@ Fired if:
  - the peer repeatedly sent invalid data
 
 ```js
-wire.ut_metadata.on('warning', function (err) {
+wire.ut_metadata.on('warning', err => {
   console.log(err.message)
 })
 ```

--- a/index.js
+++ b/index.js
@@ -1,240 +1,240 @@
-var bencode = require('bencode')
-var BitField = require('bitfield')
-var debug = require('debug')('ut_metadata')
-var EventEmitter = require('events').EventEmitter
-var inherits = require('inherits')
-var sha1 = require('simple-sha1')
+const { EventEmitter } = require('events')
+const bencode = require('bencode')
+const BitField = require('bitfield')
+const debug = require('debug')('ut_metadata')
+const sha1 = require('simple-sha1')
 
-var MAX_METADATA_SIZE = 10000000 // 10MB
-var BITFIELD_GROW = 1000
-var PIECE_LENGTH = 16 * 1024
+const MAX_METADATA_SIZE = 10000000 // 10MB
+const BITFIELD_GROW = 1000
+const PIECE_LENGTH = 16 * 1024
 
-module.exports = function (metadata) {
-  inherits(utMetadata, EventEmitter)
+module.exports = metadata => {
+  class utMetadata extends EventEmitter {
+    constructor (wire) {
+      super()
 
-  function utMetadata (wire) {
-    EventEmitter.call(this)
+      this._wire = wire
 
-    this._wire = wire
+      this._metadataComplete = false
+      this._metadataSize = null
+      this._remainingRejects = null // how many reject messages to tolerate before quitting
+      this._fetching = false
 
-    this._metadataComplete = false
-    this._metadataSize = null
-    this._remainingRejects = null // how many reject messages to tolerate before quitting
-    this._fetching = false
+      // The largest .torrent file that I know of is ~1-2MB, which is ~100 pieces.
+      // Therefore, cap the bitfield to 10x that (1000 pieces) so a malicious peer can't
+      // make it grow to fill all memory.
+      this._bitfield = new BitField(0, { grow: BITFIELD_GROW })
 
-    // The largest .torrent file that I know of is ~1-2MB, which is ~100 pieces.
-    // Therefore, cap the bitfield to 10x that (1000 pieces) so a malicious peer can't
-    // make it grow to fill all memory.
-    this._bitfield = new BitField(0, { grow: BITFIELD_GROW })
+      if (Buffer.isBuffer(metadata)) {
+        this.setMetadata(metadata)
+      }
+    }
 
-    if (Buffer.isBuffer(metadata)) {
-      this.setMetadata(metadata)
+    onHandshake (infoHash, peerId, extensions) {
+      this._infoHash = infoHash
+    }
+
+    onExtendedHandshake (handshake) {
+      if (!handshake.m || !handshake.m.ut_metadata) {
+        return this.emit('warning', new Error('Peer does not support ut_metadata'))
+      }
+      if (!handshake.metadata_size) {
+        return this.emit('warning', new Error('Peer does not have metadata'))
+      }
+      if (typeof handshake.metadata_size !== 'number' ||
+          MAX_METADATA_SIZE < handshake.metadata_size ||
+          handshake.metadata_size <= 0) {
+        return this.emit('warning', new Error('Peer gave invalid metadata size'))
+      }
+
+      this._metadataSize = handshake.metadata_size
+      this._numPieces = Math.ceil(this._metadataSize / PIECE_LENGTH)
+      this._remainingRejects = this._numPieces * 2
+
+      if (this._fetching) {
+        this._requestPieces()
+      }
+    }
+
+    onMessage (buf) {
+      let dict
+      let trailer
+      try {
+        const str = buf.toString()
+        const trailerIndex = str.indexOf('ee') + 2
+        dict = bencode.decode(str.substring(0, trailerIndex))
+        trailer = buf.slice(trailerIndex)
+      } catch (err) {
+        // drop invalid messages
+        return
+      }
+
+      switch (dict.msg_type) {
+        case 0:
+          // ut_metadata request (from peer)
+          // example: { 'msg_type': 0, 'piece': 0 }
+          this._onRequest(dict.piece)
+          break
+        case 1:
+          // ut_metadata data (in response to our request)
+          // example: { 'msg_type': 1, 'piece': 0, 'total_size': 3425 }
+          this._onData(dict.piece, trailer, dict.total_size)
+          break
+        case 2:
+          // ut_metadata reject (peer doesn't have piece we requested)
+          // { 'msg_type': 2, 'piece': 0 }
+          this._onReject(dict.piece)
+          break
+      }
+    }
+
+    /**
+     * Ask the peer to send metadata.
+     * @public
+     */
+    fetch () {
+      if (this._metadataComplete) {
+        return
+      }
+      this._fetching = true
+      if (this._metadataSize) {
+        this._requestPieces()
+      }
+    }
+
+    /**
+     * Stop asking the peer to send metadata.
+     * @public
+     */
+    cancel () {
+      this._fetching = false
+    }
+
+    setMetadata (metadata) {
+      if (this._metadataComplete) return true
+      debug('set metadata')
+
+      // if full torrent dictionary was passed in, pull out just `info` key
+      try {
+        const info = bencode.decode(metadata).info
+        if (info) {
+          metadata = bencode.encode(info)
+        }
+      } catch (err) {}
+
+      // check hash
+      if (this._infoHash && this._infoHash !== sha1.sync(metadata)) {
+        return false
+      }
+
+      this.cancel()
+
+      this.metadata = metadata
+      this._metadataComplete = true
+      this._metadataSize = this.metadata.length
+      this._wire.extendedHandshake.metadata_size = this._metadataSize
+
+      this.emit('metadata', bencode.encode({ info: bencode.decode(this.metadata) }))
+
+      return true
+    }
+
+    _send (dict, trailer) {
+      let buf = bencode.encode(dict)
+      if (Buffer.isBuffer(trailer)) {
+        buf = Buffer.concat([buf, trailer])
+      }
+      this._wire.extended('ut_metadata', buf)
+    }
+
+    _request (piece) {
+      this._send({ msg_type: 0, piece })
+    }
+
+    _data (piece, buf, totalSize) {
+      const msg = { msg_type: 1, piece }
+      if (typeof totalSize === 'number') {
+        msg.total_size = totalSize
+      }
+      this._send(msg, buf)
+    }
+
+    _reject (piece) {
+      this._send({ msg_type: 2, piece })
+    }
+
+    _onRequest (piece) {
+      if (!this._metadataComplete) {
+        this._reject(piece)
+        return
+      }
+      const start = piece * PIECE_LENGTH
+      let end = start + PIECE_LENGTH
+      if (end > this._metadataSize) {
+        end = this._metadataSize
+      }
+      const buf = this.metadata.slice(start, end)
+      this._data(piece, buf, this._metadataSize)
+    }
+
+    _onData (piece, buf, totalSize) {
+      if (buf.length > PIECE_LENGTH) {
+        return
+      }
+      buf.copy(this.metadata, piece * PIECE_LENGTH)
+      this._bitfield.set(piece)
+      this._checkDone()
+    }
+
+    _onReject (piece) {
+      if (this._remainingRejects > 0 && this._fetching) {
+        // If we haven't been rejected too much, then try to request the piece again
+        this._request(piece)
+        this._remainingRejects -= 1
+      } else {
+        this.emit('warning', new Error('Peer sent "reject" too much'))
+      }
+    }
+
+    _requestPieces () {
+      this.metadata = Buffer.alloc(this._metadataSize)
+      for (let piece = 0; piece < this._numPieces; piece++) {
+        this._request(piece)
+      }
+    }
+
+    _checkDone () {
+      let done = true
+      for (let piece = 0; piece < this._numPieces; piece++) {
+        if (!this._bitfield.get(piece)) {
+          done = false
+          break
+        }
+      }
+      if (!done) return
+
+      // attempt to set metadata -- may fail sha1 check
+      const success = this.setMetadata(this.metadata)
+
+      if (!success) {
+        this._failedMetadata()
+      }
+    }
+
+    _failedMetadata () {
+      // reset bitfield & try again
+      this._bitfield = new BitField(0, { grow: BITFIELD_GROW })
+      this._remainingRejects -= this._numPieces
+      if (this._remainingRejects > 0) {
+        this._requestPieces()
+      } else {
+        this.emit('warning', new Error('Peer sent invalid metadata'))
+      }
     }
   }
 
   // Name of the bittorrent-protocol extension
   utMetadata.prototype.name = 'ut_metadata'
-
-  utMetadata.prototype.onHandshake = function (infoHash, peerId, extensions) {
-    this._infoHash = infoHash
-  }
-
-  utMetadata.prototype.onExtendedHandshake = function (handshake) {
-    if (!handshake.m || !handshake.m.ut_metadata) {
-      return this.emit('warning', new Error('Peer does not support ut_metadata'))
-    }
-    if (!handshake.metadata_size) {
-      return this.emit('warning', new Error('Peer does not have metadata'))
-    }
-    if (typeof handshake.metadata_size !== 'number' ||
-        MAX_METADATA_SIZE < handshake.metadata_size ||
-        handshake.metadata_size <= 0) {
-      return this.emit('warning', new Error('Peer gave invalid metadata size'))
-    }
-
-    this._metadataSize = handshake.metadata_size
-    this._numPieces = Math.ceil(this._metadataSize / PIECE_LENGTH)
-    this._remainingRejects = this._numPieces * 2
-
-    if (this._fetching) {
-      this._requestPieces()
-    }
-  }
-
-  utMetadata.prototype.onMessage = function (buf) {
-    var dict, trailer
-    try {
-      var str = buf.toString()
-      var trailerIndex = str.indexOf('ee') + 2
-      dict = bencode.decode(str.substring(0, trailerIndex))
-      trailer = buf.slice(trailerIndex)
-    } catch (err) {
-      // drop invalid messages
-      return
-    }
-
-    switch (dict.msg_type) {
-      case 0:
-        // ut_metadata request (from peer)
-        // example: { 'msg_type': 0, 'piece': 0 }
-        this._onRequest(dict.piece)
-        break
-      case 1:
-        // ut_metadata data (in response to our request)
-        // example: { 'msg_type': 1, 'piece': 0, 'total_size': 3425 }
-        this._onData(dict.piece, trailer, dict.total_size)
-        break
-      case 2:
-        // ut_metadata reject (peer doesn't have piece we requested)
-        // { 'msg_type': 2, 'piece': 0 }
-        this._onReject(dict.piece)
-        break
-    }
-  }
-
-  /**
-   * Ask the peer to send metadata.
-   * @public
-   */
-  utMetadata.prototype.fetch = function () {
-    if (this._metadataComplete) {
-      return
-    }
-    this._fetching = true
-    if (this._metadataSize) {
-      this._requestPieces()
-    }
-  }
-
-  /**
-   * Stop asking the peer to send metadata.
-   * @public
-   */
-  utMetadata.prototype.cancel = function () {
-    this._fetching = false
-  }
-
-  utMetadata.prototype.setMetadata = function (metadata) {
-    if (this._metadataComplete) return true
-    debug('set metadata')
-
-    // if full torrent dictionary was passed in, pull out just `info` key
-    try {
-      var info = bencode.decode(metadata).info
-      if (info) {
-        metadata = bencode.encode(info)
-      }
-    } catch (err) {}
-
-    // check hash
-    if (this._infoHash && this._infoHash !== sha1.sync(metadata)) {
-      return false
-    }
-
-    this.cancel()
-
-    this.metadata = metadata
-    this._metadataComplete = true
-    this._metadataSize = this.metadata.length
-    this._wire.extendedHandshake.metadata_size = this._metadataSize
-
-    this.emit('metadata', bencode.encode({ info: bencode.decode(this.metadata) }))
-
-    return true
-  }
-
-  utMetadata.prototype._send = function (dict, trailer) {
-    var buf = bencode.encode(dict)
-    if (Buffer.isBuffer(trailer)) {
-      buf = Buffer.concat([buf, trailer])
-    }
-    this._wire.extended('ut_metadata', buf)
-  }
-
-  utMetadata.prototype._request = function (piece) {
-    this._send({ msg_type: 0, piece: piece })
-  }
-
-  utMetadata.prototype._data = function (piece, buf, totalSize) {
-    var msg = { msg_type: 1, piece: piece }
-    if (typeof totalSize === 'number') {
-      msg.total_size = totalSize
-    }
-    this._send(msg, buf)
-  }
-
-  utMetadata.prototype._reject = function (piece) {
-    this._send({ msg_type: 2, piece: piece })
-  }
-
-  utMetadata.prototype._onRequest = function (piece) {
-    if (!this._metadataComplete) {
-      this._reject(piece)
-      return
-    }
-    var start = piece * PIECE_LENGTH
-    var end = start + PIECE_LENGTH
-    if (end > this._metadataSize) {
-      end = this._metadataSize
-    }
-    var buf = this.metadata.slice(start, end)
-    this._data(piece, buf, this._metadataSize)
-  }
-
-  utMetadata.prototype._onData = function (piece, buf, totalSize) {
-    if (buf.length > PIECE_LENGTH) {
-      return
-    }
-    buf.copy(this.metadata, piece * PIECE_LENGTH)
-    this._bitfield.set(piece)
-    this._checkDone()
-  }
-
-  utMetadata.prototype._onReject = function (piece) {
-    if (this._remainingRejects > 0 && this._fetching) {
-      // If we haven't been rejected too much, then try to request the piece again
-      this._request(piece)
-      this._remainingRejects -= 1
-    } else {
-      this.emit('warning', new Error('Peer sent "reject" too much'))
-    }
-  }
-
-  utMetadata.prototype._requestPieces = function () {
-    this.metadata = Buffer.alloc(this._metadataSize)
-    for (var piece = 0; piece < this._numPieces; piece++) {
-      this._request(piece)
-    }
-  }
-
-  utMetadata.prototype._checkDone = function () {
-    var done = true
-    for (var piece = 0; piece < this._numPieces; piece++) {
-      if (!this._bitfield.get(piece)) {
-        done = false
-        break
-      }
-    }
-    if (!done) return
-
-    // attempt to set metadata -- may fail sha1 check
-    var success = this.setMetadata(this.metadata)
-
-    if (!success) {
-      this._failedMetadata()
-    }
-  }
-
-  utMetadata.prototype._failedMetadata = function () {
-    // reset bitfield & try again
-    this._bitfield = new BitField(0, { grow: BITFIELD_GROW })
-    this._remainingRejects -= this._numPieces
-    if (this._remainingRejects > 0) {
-      this._requestPieces()
-    } else {
-      this.emit('warning', new Error('Peer sent invalid metadata'))
-    }
-  }
 
   return utMetadata
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "bencode": "^2.0.0",
     "bitfield": "^2.0.0",
     "debug": "^3.1.0",
-    "inherits": "^2.0.1",
     "simple-sha1": "^2.0.0"
   },
   "devDependencies": {

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,11 +1,11 @@
-var bencode = require('bencode')
-var fixtures = require('webtorrent-fixtures')
-var Protocol = require('bittorrent-protocol')
-var test = require('tape')
-var utMetadata = require('../')
+const { leavesMetadata } = require('webtorrent-fixtures')
+const bencode = require('bencode')
+const Protocol = require('bittorrent-protocol')
+const test = require('tape')
+const utMetadata = require('../')
 
-test('wire.use(utMetadata())', function (t) {
-  var wire = new Protocol()
+test('wire.use(utMetadata())', t => {
+  const wire = new Protocol()
   wire.pipe(wire)
 
   wire.use(utMetadata())
@@ -17,15 +17,18 @@ test('wire.use(utMetadata())', function (t) {
   t.end()
 })
 
-test('wire.use(utMetadata(metadata))', function (t) {
-  var wire = new Protocol()
+test('wire.use(utMetadata(metadata))', t => {
+  const wire = new Protocol()
   wire.pipe(wire)
 
-  wire.use(utMetadata(fixtures.leavesMetadata.torrent))
+  wire.use(utMetadata(leavesMetadata.torrent))
 
   t.ok(wire.ut_metadata)
   t.ok(wire.ut_metadata.fetch)
   t.ok(wire.ut_metadata.cancel)
-  t.equal(wire.ut_metadata.metadata.toString('hex'), bencode.encode(bencode.decode(fixtures.leavesMetadata.torrent).info).toString('hex'))
+  t.equal(
+    wire.ut_metadata.metadata.toString('hex'),
+    bencode.encode(bencode.decode(leavesMetadata.torrent).info).toString('hex')
+  )
   t.end()
 })


### PR DESCRIPTION
part of https://github.com/webtorrent/webtorrent/issues/1443

Aside notes
---


It looks like a bad practice to me the way it's currently built, by recompiling the class every time You call this exported function <br>This prevent the compiler from optimizing the class 

```js
// webtorrent/ut_metadata/index.js
export = function (meta) {
  return class F {}
}

// webtorrent/webtorrent/lib/torrent.js
wire.use(utMetadata(this.metadata))
```

The way I maybe would have solve this is something like this:
```js
// webtorrent/ut_metadata/index.js
export = class F {}

// webtorrent/lib/torrent.js
wire.use(utMetadata)
wire.ut_metadata.setMetadata(this.metadata))
```

But that would be a breaking change