### PR TITLE
Update Node.js engine requirement to version 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         os:
           - ubuntu-latest
         node:
-          - '18'
+          - '22'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,18 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read # for checkout
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for trusted publishing and npm provenance
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -17,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 22
       - name: Cache
         uses: actions/cache@v5
         with:
@@ -27,10 +35,7 @@ jobs:
             ${{ runner.os }}-npm-
       - name: Install dependencies
         run: npm i
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=12.20.0"
+    "node": ">=22"
   },
   "exports": {
     "import": "./index.js"


### PR DESCRIPTION
This pull request updates the project's Node.js version requirements and improves the permissions configuration for GitHub Actions workflows. The most important changes are grouped below:

**Node.js Version Upgrades:**

* Updated the Node.js version used in both CI (`.github/workflows/ci.yml`) and Release (`.github/workflows/release.yml`) workflows from `18` to `22` to ensure compatibility with the latest Node.js features and security updates. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL13-R13) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L20-R28)
* Updated the `package.json` `engines` field to require Node.js version `>=22`.

**GitHub Actions Permissions Improvements:**

* Added explicit permissions to the Release workflow in `.github/workflows/release.yml`, granting only the necessary access for contents, issues, pull requests, and id-token, following best practices for GitHub Actions security.
* Removed the `NPM_TOKEN` from the `Install dependencies` step in the Release workflow, reducing unnecessary exposure of secrets.