### PR TITLE
chore: use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/webtorrent/ut_metadata.git"
+    "url": "https://github.com/webtorrent/ut_metadata.git"
   },
   "scripts": {
     "test": "standard && tape test/*.js"


### PR DESCRIPTION
## Summary
- replace the npm repository metadata URL with the public HTTPS GitHub URL
- keep the repository target unchanged

## Verification
- `node -e "const p=require('./package.json'); if (p.repository.url !== 'https://github.com/webtorrent/ut_metadata.git') throw new Error(p.repository.url); console.log(p.repository.url)"`
- `npm install --ignore-scripts --no-audit --no-fund`
- `npm test` (22 tests passed)
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`